### PR TITLE
Add child-friendly design to the form

### DIFF
--- a/report_form/app/globals.css
+++ b/report_form/app/globals.css
@@ -39,6 +39,11 @@ body {
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+    --playful-color-1: #FF6F61;
+    --playful-color-2: #6B5B95;
+    --playful-color-3: #88B04B;
+    --playful-color-4: #F7CAC9;
+    --playful-color-5: #92A8D1;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -65,6 +70,11 @@ body {
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+    --playful-color-1: #FF6F61;
+    --playful-color-2: #6B5B95;
+    --playful-color-3: #88B04B;
+    --playful-color-4: #F7CAC9;
+    --playful-color-5: #92A8D1;
   }
 }
 
@@ -74,5 +84,23 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+  }
+  .playful-element {
+    background-color: var(--playful-color-1);
+    color: var(--playful-color-2);
+    border-radius: 10px;
+    padding: 10px;
+    font-family: 'Comic Sans MS', cursive, sans-serif;
+  }
+  .child-friendly-icon {
+    width: 50px;
+    height: 50px;
+    background-color: var(--playful-color-3);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    color: var(--playful-color-4);
   }
 }

--- a/report_form/components/exif-location-viewer.tsx
+++ b/report_form/components/exif-location-viewer.tsx
@@ -152,7 +152,7 @@ export function ExifLocationViewer() {
   }, [location, title, comment, preview, name])
 
   return (
-    <Card className="w-full max-w-md mx-auto">
+    <Card className="w-full max-w-md mx-auto playful-element">
       <CardHeader>
         <CardTitle className="text-center">つるが空き家探検 報告フォーム</CardTitle>
       </CardHeader>
@@ -196,7 +196,7 @@ export function ExifLocationViewer() {
             <>
               <hr className="w-full border-gray-300" />
               <div className="flex items-center">
-                <MapPin className="h-6 w-6" />
+                <MapPin className="h-6 w-6 child-friendly-icon" />
                 <p>投稿のプレビュー</p>
               </div>
             </>


### PR DESCRIPTION
Related to #1

Update the form design to be more child-friendly and engaging for elementary school students.

* **Color Scheme**: Add new playful colors to the CSS variables in `report_form/app/globals.css`.
* **Styles**: Add new styles for playful elements and child-friendly icons in `report_form/app/globals.css`.
* **Form Design**: Modify the form in `report_form/components/exif-location-viewer.tsx` to include playful elements and child-friendly icons.
* **Icons**: Update the `MapPin` icon to use the new child-friendly icon style in `report_form/components/exif-location-viewer.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/soichiro-akasaka/fukui-hackathon/issues/1?shareId=1ed65278-3947-4132-b7a1-899600233e46).